### PR TITLE
Aded CMake as a build tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ install(FILES src/args.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(EXPORT  ${LIB_NAME}Targets
     FILE        ${LIB_NAME}Targets.cmake
-    NAMESPACE   dmullholl::
+    NAMESPACE   dmulholl::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LIB_NAME}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 3.16)
+project(args
+    VERSION     3.3.1
+    LANGUAGES   C
+    DESCRIPTION "An argument-parsing library for C."
+)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+# ------------------------------------------------ #
+#  Setting a variable for the name of the library  #
+# ------------------------------------------------ #
+set(LIB_NAME args)
+
+# ---------------------------------- #
+#  Set C standard and compile flags  #
+# ---------------------------------- #
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_FLAGS_COMMANDS
+    "${CMAKE_C_FLAGS} -Wall -Wextra --pedantic -Wno-unused-parameter")
+
+add_library(${LIB_NAME}
+    src/args.c
+)
+    
+target_include_directories(${LIB_NAME}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:include>
+)
+
+# ------------------------- #
+#  Set installation config  #
+# ------------------------- #
+
+install(TARGETS         ${LIB_NAME}
+    EXPORT              ${LIB_NAME}Targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(FILES src/args.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# --------------------------------------------------------------- #
+#  Export targets so that they can be fetched by another project  #
+# --------------------------------------------------------------- #
+
+install(EXPORT  ${LIB_NAME}Targets
+    FILE        ${LIB_NAME}Targets.cmake
+    NAMESPACE   dmullholl::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LIB_NAME}
+)
+
+configure_package_config_file(
+    cmake/argsConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LIB_NAME}
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${LIB_NAME}
+)
+
+# ----------------------------------- #
+#  Special config for build and test  #
+# ----------------------------------- #
+
+include(cmake/tests.cmake)
+include(cmake/examples.cmake)

--- a/cmake/argsConfig.cmake.in
+++ b/cmake/argsConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/argsTargets.cmake")

--- a/cmake/examples.cmake
+++ b/cmake/examples.cmake
@@ -1,0 +1,33 @@
+# ------------------------------- #
+#  Optionally build all examples  #
+# ------------------------------- #
+
+if(BUILD_EXAMPLES)
+    add_executable(example1 ${CMAKE_SOURCE_DIR}/src/example1.c)
+    add_executable(example2 ${CMAKE_SOURCE_DIR}/src/example2.c)
+
+    target_link_libraries(example1 PRIVATE args)
+    target_link_libraries(example2 PRIVATE args)
+
+    target_include_directories(example1 PRIVATE ${CMAKE_SOURCE_DIR}/src)
+endif()
+
+# --------------------------- #
+#  Optionally build example1  #
+# --------------------------- #
+
+if(BUILD_EXAMPLE1 AND NOT BUILD_EXAMPLES)
+    add_executable(example1 ${CMAKE_SOURCE_DIR}/src/example1.c)
+    target_link_libraries(example1 PRIVATE args)
+    target_include_directories(example1 PRIVATE ${CMAKE_SOURCE_DIR}/src)
+endif()
+
+# --------------------------- #
+#  Optionally build example2  #
+# --------------------------- #
+
+if(BUILD_EXAMPLE2 AND NOT BUILD_EXAMPLES)
+    add_executable(example2 ${CMAKE_SOURCE_DIR}/src/example2.c)
+    target_link_libraries(example2 PRIVATE args)
+    target_include_directories(example2 PRIVATE ${CMAKE_SOURCE_DIR}/src)
+endif()

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,0 +1,12 @@
+# ---------------------------- #
+#  Optionally build the tests  #
+# ---------------------------- #
+
+if(BUILD_TESTS)
+    add_executable(tests ${CMAKE_SOURCE_DIR}/src/tests.c)
+    target_link_libraries(tests PRIVATE args)
+    target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+    enable_testing() ## Enables the possibility to run ctest
+    add_test(NAME tests COMMAND tests)
+endif()


### PR DESCRIPTION
I was looking for a nice C/C++ arg parser, where I stumbled upon your repository. I however like to build my projects with CMake and manage my external dependencies with the `FetchContent` command. I added the necessarry files to do that and build and install it locally by downloading cloning the repo. For local installation a user just has to run
```bash
$ mkdir build && cd build
$ cmake ..
$ sudo make install
```
if the user wants to run tests they have to run
```bash
$ mkdir build && cd build
$ cmake -DBUILD_TESTS ..
$ ctest
```
Similarly you can also build the examples like that. Now if you want to use the library after installation in a project you just have to follow this simple example:
```cmake
cmake_minimum_required(VERSION 3.16)
project(test)

find_package(args REQUIRED)

add_executable(test main.c)
target_link_libraries(test PRIVATE args)
```
Or if the library should not be installed globally but only for building a binary one can use `FetchContent`:
```cmake
cmake_minimum_required(VERSION 3.16)
project(test)
include(FetchContent)

FetchContent_Declare(
    args
    GIT_REPOSITORY https://github.com/nmulholl/args.git
    GIT_TAG 3.3.1 # This is just a preliminary tag. If you change it, note that you have to change the version info in CMakeLists.txt
)
FetchContent_MakeAvailable(args)

add_executable(test main.c)
target_link_libraries(test args)
```
Cheers
Linus